### PR TITLE
Missing file and resize fix

### DIFF
--- a/Droid/Renderers/LabelTypefaceRenderer.cs
+++ b/Droid/Renderers/LabelTypefaceRenderer.cs
@@ -52,5 +52,11 @@ namespace FontIconsInXamarinForms.Droid.Renderers
 
 			FontUtils.ApplyTypeface(Control, Element.FontFamily);
 		}
+
+        protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged (sender, e);
+            FontUtils.ApplyTypeface (Control, Element.FontFamily);
+        }
 	}
 }

--- a/FontIconsInXamarinForms/FontIconsInXamarinForms.csproj
+++ b/FontIconsInXamarinForms/FontIconsInXamarinForms.csproj
@@ -41,6 +41,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Styling\FontAwesomeIcons.cs" />
     <Compile Include="Styling\Fonts.cs" />
+    <Compile Include="DoubleToColorConverter.cs" />
+    <Compile Include="DoubleToIntConverter.cs" />
+    <Compile Include="ViewModelLocator.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">

--- a/FontIconsInXamarinForms/FontIconsInXamarinForms.xaml.cs
+++ b/FontIconsInXamarinForms/FontIconsInXamarinForms.xaml.cs
@@ -7,6 +7,8 @@ namespace FontIconsInXamarinForms
 		public FontIconsInXamarinFormsPage()
 		{
 			InitializeComponent();
+            colorSlider.WidthRequest = 100;
+            sizeSlider.WidthRequest = 100;
 		}
 	}
 }


### PR DESCRIPTION
This fixes 2 issues:

1. File references for ViewModelLocator.cs, DoubleToColorConverter.cs & DoubleToIntConverter.cs
2. Resizing on Android causes the FontAwesome image to disappear.